### PR TITLE
fixed failing unit tests - missing CKEDITOR

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -18,7 +18,7 @@ module.exports = function(config) {
             'app/bower_components/angular-mocks/angular-mocks.js',
             'app/bower_components/angular-elastic/elastic.js',
             'app/bower_components/jspdf/dist/jspdf.source.js',
-            'app/bower_components/ckeditor/ckeditor.js',
+            'app/bower_components/ng-ckeditor/libs/ckeditor/ckeditor.js',
             'app/bower_components/ng-ckeditor/ng-ckeditor.js',
             'app/js/forms-angular.js',
             'app/js/**/*.js',

--- a/config/karma.midway.conf.js
+++ b/config/karma.midway.conf.js
@@ -18,7 +18,7 @@ module.exports = function(config) {
             'app/bower_components/angular-mocks/angular-mocks.js',
             'app/bower_components/jspdf/dist/jspdf.source.js',
             'app/bower_components/angular-elastic/elastic.js',
-            'app/bower_components/ckeditor/ckeditor.js',
+            'app/bower_components/ng-ckeditor/libs/ckeditor/ckeditor.js',
             'app/bower_components/ng-ckeditor/ng-ckeditor.js',
             'app/js/forms-angular.js',
             'app/js/**/*.js',


### PR DESCRIPTION
WARN [watcher]: Pattern "app/bower_components/ckeditor/ckeditor.js" does not match any file.

Now using the ckeditor package provided by ng-ckeditor
