### PR TITLE
List and Limit params must be numeric

### DIFF
--- a/server/data_form.js
+++ b/server/data_form.js
@@ -797,8 +797,8 @@ DataForm.prototype.collectionGet = function () {
         try {
             var aggregationParam = urlParts.query.a ? JSON.parse(urlParts.query.a) : null;
             var findParam = urlParts.query.f ? JSON.parse(urlParts.query.f) : {};
-            var limitParam = urlParts.query.l ? JSON.parse(urlParts.query.l) : {};
-            var skipParam = urlParts.query.s ? JSON.parse(urlParts.query.s) : {};
+            var limitParam = urlParts.query.l ? JSON.parse(urlParts.query.l) : 0;
+            var skipParam = urlParts.query.s ? JSON.parse(urlParts.query.s) : 0;
             var orderParam = urlParts.query.o ? JSON.parse(urlParts.query.o) : req.resource.options.listOrder;
             var self = this;
             this.filteredFind(req.resource, req, aggregationParam, findParam, orderParam, limitParam, skipParam, function (err, docs) {

--- a/server/data_form.ts
+++ b/server/data_form.ts
@@ -876,8 +876,8 @@ DataForm.prototype.collectionGet = function () {
     try {
       var aggregationParam  = urlParts.query.a ? JSON.parse(urlParts.query.a) : null;
       var findParam         = urlParts.query.f ? JSON.parse(urlParts.query.f) : {};
-      var limitParam        = urlParts.query.l ? JSON.parse(urlParts.query.l) : {};
-      var skipParam         = urlParts.query.s ? JSON.parse(urlParts.query.s) : {};
+      var limitParam        = urlParts.query.l ? JSON.parse(urlParts.query.l) : 0;
+      var skipParam         = urlParts.query.s ? JSON.parse(urlParts.query.s) : 0;
       var orderParam        = urlParts.query.o ? JSON.parse(urlParts.query.o) : req.resource.options.listOrder;
 
       var self = this;


### PR DESCRIPTION
…cannot be {} in mongo > v3

#77 's problem arose in the server-side script as well, while using the /api/ModelName endpoint.  
I replaced the default empty in list and limit params with `0` in `data_form.ts`.  I had to manually update `data_form.js` as `gulp all` did not rebuild the .js file.  Not familiar enough with ts/gulp to track this down.