### PR TITLE
Fix setUpCustomLookupOptions to correctly handle blank items

### DIFF
--- a/src/client/js/services/record-handler.ts
+++ b/src/client/js/services/record-handler.ts
@@ -1409,6 +1409,9 @@ module fng.services {
           if (!data) {
             return;
           }
+          if (Array.isArray(data)) {
+            data = data.filter((i) => i !== undefined && i !== null);
+          }
           data = convertForeignKeys(schemaElement, data, options, ids);
           setData($scope.record, schemaElement.name, undefined, data);
         }        


### PR DESCRIPTION
Found an unlikely case bug here (something I added a long time ago) while working on the client-side optimisations branch.  The bug is slightly more likely to occur in that branch but the fix is independent of it and could go out any time.